### PR TITLE
fixed gtk import for todoist_task

### DIFF
--- a/user/.local/bin/todoist_task
+++ b/user/.local/bin/todoist_task
@@ -4,6 +4,8 @@ from builtins import super
 from os import path
 
 import todoist
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 CONFIG = path.expanduser("~/.config/todoist")


### PR DESCRIPTION
fixed PyGIWarning: Gtk was imported without specifying a version first.



P.S. I don't know Python, so there might be some extra syntactic sugar, but this fix worked for me ;)

Thanks so much for this! Would be nice if Todoist would implement the quick add for Linux already... it's been 3+ years